### PR TITLE
Full auto

### DIFF
--- a/get-lm-desk.sh
+++ b/get-lm-desk.sh
@@ -693,7 +693,7 @@ function configure_beeai {
         gb_mem=$(system_profiler -xml SPHardwareDataType \
             | grep -A 1 physical_memory \
             | grep "GB" | sed 's,[^0-9]*,,g')
-        if [ "$gb_mem" == "64" ]
+        if [ "$gb_mem" -ge "64" ]
         then
             context_size=128
         elif [ "$gb_mem" == "32" ]

--- a/get-lm-desk.sh
+++ b/get-lm-desk.sh
@@ -49,6 +49,8 @@ Options:
     -b, --brew-bin           Specify the path to brew (default is ${brew_bin})
     -o, --ollama-bin         Specify the path to ollama (default is ${ollama_bin})
     -g, --git-bin            Specify the path to git (default is ${git_bin})
+    -B, --beeai-bin          Specify the path to beeai (default is ${beeai_bin})
+    -O, --obee-bin           Specify the path to obee (default is ${obee_bin})
     -j, --jq-bin             Specify the path to jq (default is ${jq_bin})
     -i, --install-path       Specify the install path for tools
     -m, --models             Specify the models to pull as a space-separated string (default is ${models})
@@ -76,6 +78,14 @@ while [ $# -gt 0 ]; do
             ;;
         --git-bin|-g)
             git_bin="$2"
+            shift
+            ;;
+        --beeai-bin|-B)
+            beeai_bin="$2"
+            shift
+            ;;
+        --obee-bin|-O)
+            obee_bin="$2"
             shift
             ;;
         --jq-bin|-j)
@@ -309,6 +319,8 @@ function report_installed {
     brown "- uv: $uv_bin"
     brown "- obee: $obee_bin"
     brown "- git: $git_bin"
+    brown "- beeai: $beeai_bin"
+    brown "- obee: $obee_bin"
     brown "- jq: $jq_bin"
     brown $(term_bar -)
 }

--- a/get-lm-desk.sh
+++ b/get-lm-desk.sh
@@ -31,16 +31,7 @@ install_path=""
 models="granite3.3 granite3.2-vision"
 agents="gpt-researcher aider"
 dry_run="0"
-
-# If running without a TTY, always assume 'yes'
-if [[ -t 1 ]]
-then
-    yes="0"
-else
-    echo "RUNNING NON-INTERACTIVE"
-    yes="1"
-fi
-
+yes="1"
 
 help_str="Usage: $0 [options]
 Options:
@@ -55,7 +46,7 @@ Options:
     -i, --install-path       Specify the install path for tools
     -m, --models             Specify the models to pull as a space-separated string (default is ${models})
     -a, --agents             Specify the agents to configure in obee as a space-separated string (default is ${agents})
-    -y, --yes                Skip confirmation prompt
+    -k, --ask                Ask for confirmation
     -n, --dry-run            Run without installing anything"
 
 while [ $# -gt 0 ]; do
@@ -100,8 +91,8 @@ while [ $# -gt 0 ]; do
             models="$2"
             shift
             ;;
-        --yes|-y)
-            yes="1"
+        --ask|-k)
+            yes="0"
             ;;
         --dry-run|-n)
             dry_run="1"
@@ -114,6 +105,13 @@ while [ $# -gt 0 ]; do
     esac
     shift
 done
+
+# If running without a TTY, always assume 'yes'
+if ! [[ -t 1 ]]
+then
+    echo "RUNNING NON-INTERACTIVE"
+    yes="1"
+fi
 
 ## Helpers #####################################################################
 


### PR DESCRIPTION
## Related PRs

This PR is a follow-on from #11 that also handles the context length issue

## What this PR does / why we need it

With `beeai env setup`, when choosing Ollama, the system automatically makes a "special" model for `beeai` that explicitly encodes the context length. By default, Ollama boots all models with small context lengths to avoid using too many resources for simple chat use cases, however when given longer requests the context is silently truncated resulting in terrible hallucinations. The `beeai` solution is a nice fix to this, but there is no way to script the `beeai env setup` answers, so instead we simply replicate the functionality here.